### PR TITLE
feat: Improve typings to validate arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,7 @@ function stringifyString (string: string): string {
  * @param {*}        args  Function arguments.
  * @returns {string} The runnable string.
  */
-function createRunString (func: Function, ...args: any[]): string {
+function createRunString<T extends (...args: any[]) => unknown> (func: T, ...args: Parameters<T>): string {
   if (typeof func !== 'function') {
     throw new Error('expected a function but got ' + typeof func)
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -49,8 +49,22 @@ describe('index.js', function () {
     })
 
     it('should keep the parameters', function () {
-      const result: string = index(function (foo: any, bar: any) {})
+      const result: string = index(function (foo: any, bar: any) {}, undefined, undefined)
       if (!/function\s*\(foo,\s*bar\)/.test(result)) {
+        throw new Error('parameters not kept: ' + result)
+      }
+    })
+
+    it('should allow optional parameters', function () {
+      const result: string = index(function (foo: any, bar?: any) {}, undefined)
+      if (!/function\s*\(foo,\s*bar\)/.test(result)) {
+        throw new Error('parameters not kept: ' + result)
+      }
+    })
+
+    it('should allow default parameters', function () {
+      const result: string = index(function (foo: any, bar: any = 42) {}, undefined)
+      if (!/function\s*\(foo,\s*bar\s*=\s*42\)/.test(result)) {
         throw new Error('parameters not kept: ' + result)
       }
     })
@@ -58,7 +72,7 @@ describe('index.js', function () {
     it('should stringify the contents', function () {
       const result: string = index(function (a: boolean, b: boolean) {
         return a || b
-      })
+      }, true, false)
       if (!/\{\s*return a \|\| b;?\s*\}/.test(result)) {
         throw new Error('contents not stringified correctly: ' + result)
       }
@@ -67,7 +81,7 @@ describe('index.js', function () {
     it('should stringify arrow functions', function () {
       const result: string = index((a: boolean, b: boolean) => {
         return a || b
-      })
+      }, true, false)
       if (!/\(a,\s*b\)\s*=>\s*\{\s*return a \|\| b;?\s*\}/.test(result)) {
         throw new Error('invalid stringification: ' + result)
       }
@@ -105,8 +119,8 @@ describe('index.js', function () {
     it('should escape serialized strings', function () {
       const result: string = index(function (a: string, b: string) {
         return a + ' ' + b
-      }, 'foo"bar\\"\n')
-      if (!result.includes(')("foo\\"bar\\\\\\"\\n")')) {
+      }, 'foo"bar\\"\n', 'baz')
+      if (!result.includes(')("foo\\"bar\\\\\\"\\n", "baz")')) {
         throw new Error('incorrect serialization: ' + result)
       }
     })


### PR DESCRIPTION
This makes it possible to validate the type and number of args passed to the
function in createRunString.

For instance, if I forget to add an argument, or if the type is not matching,
TypeScript will throw an error.
